### PR TITLE
Using the Authorization header instead of a custom Auth Header

### DIFF
--- a/anomalo/client.go
+++ b/anomalo/client.go
@@ -96,7 +96,7 @@ func (c *Client) apiCallWithBody(endpoint string, method string, jsonParams stri
 		req.URL.RawQuery = params.Encode()
 	}
 
-	req.Header.Set("X-Anomalo-Token", c.Token)
+	req.Header.Set("Authorization", "Bearer "+c.Token)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.getClient().Do(req)


### PR DESCRIPTION
Anomalo prefers the Authorization header. `X-Anomalo-...` is deprecated.