### PR TITLE
Various Anomalo API Updates (Anomalo API Version 0.104.0)

### DIFF
--- a/anomalo/structs.go
+++ b/anomalo/structs.go
@@ -17,13 +17,15 @@ type GetTableResponse struct {
 		Description string `json:"description,omitempty"`
 		ID          int    `json:"id,omitempty"`
 	} `json:"notification_channel,omitempty"`
-	RecentStatus struct { // TODO is this different?
-		IntervalID           int       `json:"interval_id,omitempty"`
-		LatestRunChecksJobID string    `json:"latest_run_checks_job_id,omitempty"`
-		Status               string    `json:"status,omitempty"`
-		StatusDisplay        string    `json:"status_display,omitempty"`
-		TimePeriodEnd        time.Time `json:"time_period_end,omitempty"`
-		TimePeriodStart      time.Time `json:"time_period_start,omitempty"`
+	RecentStatus struct {
+		RecentIntervals []struct {
+			IntervalID           int       `json:"interval_id,omitempty"`
+			LatestRunChecksJobID string    `json:"latest_run_checks_job_id,omitempty"`
+			Status               string    `json:"status,omitempty"`
+			StatusDisplay        string    `json:"status_display,omitempty"`
+			TimePeriodEnd        time.Time `json:"time_period_end,omitempty"`
+			TimePeriodStart      time.Time `json:"time_period_start,omitempty"`
+		} `json:"recent_intervals,omitempty"`
 	} `json:"recent_status,omitempty"`
 	Warehouse struct {
 		ID   int    `json:"id,omitempty"`

--- a/anomalo/structs.go
+++ b/anomalo/structs.go
@@ -17,7 +17,7 @@ type GetTableResponse struct {
 		Description string `json:"description,omitempty"`
 		ID          int    `json:"id,omitempty"`
 	} `json:"notification_channel,omitempty"`
-	RecentStatus struct {
+	RecentStatus struct { // TODO is this different?
 		IntervalID           int       `json:"interval_id,omitempty"`
 		LatestRunChecksJobID string    `json:"latest_run_checks_job_id,omitempty"`
 		Status               string    `json:"status,omitempty"`
@@ -84,6 +84,7 @@ type ConfigureTableResponse struct {
 type Check struct {
 	CheckID       int    `json:"check_id,omitempty"`
 	CheckStaticID int    `json:"check_static_id,omitempty"`
+	Ref           string `json:"ref,omitempty"`
 	CheckType     string `json:"check_type,omitempty"`
 	Config        struct {
 		Metadata struct {
@@ -122,7 +123,9 @@ type CreateCheckRequest struct {
 }
 
 type CreateCheckResponse struct {
-	CheckID int `json:"check_id,omitempty"`
+	CheckID       int    `json:"check_id,omitempty"`
+	CheckRef      string `json:"check_ref,omitempty"`
+	CheckStaticId string `json:"check_static_id,omitempty"`
 }
 
 type DeleteCheckRequest struct {


### PR DESCRIPTION
Unclear if the update to `GetTableResponse.RecentStatus` was backwards incompatible - but without this change it'll always be empty with the new API.

I need to ask Anomalo folks + ask if we can specify API versions to avoid breaking changes.

<img width="372" alt="Screenshot 2023-09-16 at 5 29 40 PM" src="https://github.com/square/anomalo-go/assets/73117346/986c6c5e-2eb2-4101-b594-047c6280f41a">
