### PR TITLE
Fixing JSON name of CheckRef in CreateCheckResponse

### DIFF
--- a/anomalo/structs.go
+++ b/anomalo/structs.go
@@ -126,7 +126,7 @@ type CreateCheckRequest struct {
 
 type CreateCheckResponse struct {
 	CheckID       int    `json:"check_id,omitempty"`
-	CheckRef      string `json:"check_ref,omitempty"`
+	CheckRef      string `json:"ref,omitempty"`
 	CheckStaticId int    `json:"check_static_id,omitempty"`
 }
 


### PR DESCRIPTION
There's an error in the anomalo API documenation. This is called `ref` in the response to `CreateCheck`, not `check_ref`