### PR TITLE
GetTableInformationFromRequest

### DIFF
--- a/anomalo/client.go
+++ b/anomalo/client.go
@@ -151,15 +151,13 @@ func (c *Client) GetTableInformation(tableName string) (*GetTableResponse, error
 	return data, nil
 }
 
-// GetTableInformationWithWarehouseID takes two arguments
-// - `tableName` is the name of the schema without the warehouse string prefix
-// - `warehouseID` is the integer ID of the corresponding warehouse
+// GetTableInformationFromRequest supports looking up a table via query params
 //
 // This method was added because `GetTableInformation` will fail if a table's
 // warehouse name is not unique within an Anomalo workspace. Therefore, if
 // there are multiple warehouses with the same name, then you should differentiate
 // via the warehouseID parameter instead.
-func (c *Client) GetTableInformationWithWarehouseID(req GetTableInformationRequest) (*GetTableResponse, error) {
+func (c *Client) GetTableInformationFromRequest(req GetTableInformationRequest) (*GetTableResponse, error) {
 	var data *GetTableResponse
 	reqJson, err := json.Marshal(req)
 	resp, err := c.apiCallWithBody("get_table_information", http.MethodGet, string(reqJson))

--- a/anomalo/client.go
+++ b/anomalo/client.go
@@ -133,6 +133,9 @@ func (c *Client) Ping() (*PingResponse, error) {
 
 // GetTableInformation looks up a table by `tableName`.
 // `tableName` must start with its warehouse name.
+//
+// For example, a Snowflake table with a warehouse called `square` and a table
+// called `items.variations` should be referenced as `square.items.variations`.
 func (c *Client) GetTableInformation(tableName string) (*GetTableResponse, error) {
 	var data *GetTableResponse
 	req := fmt.Sprintf("{\"table_name\": \"%s\"}", tableName)

--- a/anomalo/client.go
+++ b/anomalo/client.go
@@ -159,10 +159,10 @@ func (c *Client) GetTableInformation(tableName string) (*GetTableResponse, error
 // warehouse name is not unique within an Anomalo workspace. Therefore, if
 // there are multiple warehouses with the same name, then you should differentiate
 // via the warehouseID parameter instead.
-func (c *Client) GetTableInformationWithWarehouseID(tableName string, warehouseID int) (*GetTableResponse, error) {
+func (c *Client) GetTableInformationWithWarehouseID(req GetTableInformationRequest) (*GetTableResponse, error) {
 	var data *GetTableResponse
-	req := fmt.Sprintf("{\"table_name\": \"%s\", \"warehouse_id\": \"%d\"}", tableName, warehouseID)
-	resp, err := c.apiCallWithBody("get_table_information", http.MethodGet, req)
+	reqJson, err := json.Marshal(req)
+	resp, err := c.apiCallWithBody("get_table_information", http.MethodGet, string(reqJson))
 	if err != nil {
 		return nil, err
 	}

--- a/anomalo/structs.go
+++ b/anomalo/structs.go
@@ -14,6 +14,11 @@ type Label struct {
 	Scope string `json:"scope,omitempty"`
 }
 
+type GetTableInformationRequest struct {
+	WarehouseID int    `json:"warehouse_id,omitempty"`
+	TableName   string `json:"table_name,omitempty"`
+}
+
 type GetTableResponse struct {
 	Description         string `json:"description,omitempty"`
 	FullName            string `json:"full_name,omitempty"`

--- a/anomalo/structs.go
+++ b/anomalo/structs.go
@@ -17,6 +17,7 @@ type Label struct {
 type GetTableInformationRequest struct {
 	WarehouseID int    `json:"warehouse_id,omitempty"`
 	TableName   string `json:"table_name,omitempty"`
+	TableID     int    `json:"table_id,omitempty"`
 }
 
 type GetTableResponse struct {


### PR DESCRIPTION
Adds a new method called `GetTableInformationFromRequest`. This is added because `GetTableInformation` will fail if a table's warehouse name is not unique within an Anomalo workspace. Therefore, if there are multiple warehouses with the same name, then we need to differentiate via a warehouseID parameter instead. This reasoning has been noted in the source code.