### PR TITLE
DiscoverNewWarehouseTables

### DIFF
--- a/anomalo/structs.go
+++ b/anomalo/structs.go
@@ -244,3 +244,12 @@ type GetOrganizationsResponse struct {
 type ChangeOrganizationResponse struct {
 	ID int `json:"id,omitempty"`
 }
+
+type DiscoverNewWarehouseTablesResponse struct {
+    ID                        int       `json:"id,omitempty"`
+    Name                      string    `json:"name,omitempty"`
+    LastRefreshed             time.Time `json:"last_refreshed,omitempty"`
+    LastRefreshStarted        time.Time `json:"last_refresh_started,omitempty"`
+    LastPartialRefreshed      time.Time `json:"last_partial_refreshed,omitempty"`
+    LastPartialRefreshStarted time.Time `json:"last_partial_refresh_started,omitempty"`
+}


### PR DESCRIPTION
Implements a client method for `Discover new data warehouse tables`. As part of this PR, we add some additional (shared) error handling logic. If the request returns a 429 status code, we attempt to parse the response header for the `Retry-After` value, which represents how long the user should wait before reissuing a request.